### PR TITLE
Add row selection to UI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -322,6 +322,7 @@ checksum = "f1fd7173631a4e9e2ca8b32ae2fad58aab9843ea5aaf56642661937d87e28a3e"
 dependencies = [
  "bitflags",
  "crossterm_winapi",
+ "futures-core",
  "libc",
  "mio 0.7.14",
  "parking_lot 0.12.0",
@@ -485,6 +486,7 @@ checksum = "f73fe65f54d1e12b726f517d3e2135ca3125a437b6d998caf1962961f7172d9e"
 dependencies = [
  "futures-channel",
  "futures-core",
+ "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -508,10 +510,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c09fd04b7e4073ac7156a9539b57a484a8ea920f79c7c675d05d289ab6110d3"
 
 [[package]]
+name = "futures-executor"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9420b90cfa29e327d0429f19be13e7ddb68fa1cccb09d65e5706b8c7a749b8a6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-io"
 version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc4045962a5a5e935ee2fdedaa4e08284547402885ab326734432bed5d12966b"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33c1e13800337f4d4d7a316bf45a567dbcb6ffe087f16424852d97e97a91f512"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "futures-sink"
@@ -531,11 +555,16 @@ version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b7abd5d659d9b90c8cba917f6ec750a74e2dc23902ef9cd4cc8c8b22e6036a"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
  "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -785,10 +814,13 @@ dependencies = [
  "ctrlc",
  "drain-flow",
  "duration-str",
+ "futures",
+ "futures-core",
  "itertools",
  "joinery",
  "parking_lot 0.12.0",
  "tokio",
+ "tokio-util 0.7.1",
  "tracing",
  "tracing-subscriber",
  "tui",
@@ -1767,6 +1799,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "futures-util",
  "pin-project-lite",
  "tokio",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -370,8 +370,8 @@ dependencies = [
 
 [[package]]
 name = "drain-flow"
-version = "0.2.0"
-source = "git+https://github.com/nharring-adjacent/drain-flow#e097fecc2781015e6b3e4da0e5818e20b42a2aa7"
+version = "0.3.0"
+source = "git+https://github.com/nharring-adjacent/drain-flow#51e32170f42241bd818b464159e6186229e986e4"
 dependencies = [
  "anyhow",
  "custom_derive",
@@ -692,9 +692,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "1.8.0"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282a6247722caba404c065016bbfa522806e51714c34f5dfc3e4a3a46fcb4223"
+checksum = "0f647032dfaa1f8b6dc29bd3edb7bbef4861b8b8007ebb118d6db284fd59f6ee"
 dependencies = [
  "autocfg",
  "hashbrown",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -197,9 +197,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "3.1.6"
+version = "3.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8c93436c21e4698bacadf42917db28b23017027a4deccb35dbe47a7e7840123"
+checksum = "71c47df61d9e16dc010b55dba1952a57d8c215dbb533fd13cdd13369aac73b1c"
 dependencies = [
  "atty",
  "bitflags",
@@ -215,9 +215,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "3.1.4"
+version = "3.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da95d038ede1a964ce99f49cbe27a7fb538d1da595e4b4f70b8c8f338d17bf16"
+checksum = "a3aab4734e083b809aaf5794e14e756d1c798d2c69c7f7de7a09a2f5214993c1"
 dependencies = [
  "heck 0.4.0",
  "proc-macro-error",
@@ -580,9 +580,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.12"
+version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62eeb471aa3e3c9197aa4bfeabfe02982f6dc96f750486c0bb0009ac58b26d2b"
+checksum = "37a82c6d637fc9515a4694bbf1cb2457b79d81ce52b3108bdeea58b07dd34a57"
 dependencies = [
  "bytes",
  "fnv",
@@ -593,7 +593,7 @@ dependencies = [
  "indexmap",
  "slab",
  "tokio",
- "tokio-util 0.6.9",
+ "tokio-util 0.7.1",
  "tracing",
 ]
 
@@ -786,10 +786,11 @@ checksum = "efaa7b300f3b5fe8eb6bf21ce3895e1751d9665086af2d64b42f19701015ff4f"
 
 [[package]]
 name = "lock_api"
-version = "0.4.6"
+version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88943dd7ef4a2e5a4bfa2753aaab3013e34ce2533d1996fb18ef591e315e2b3b"
+checksum = "327fa5b6a6940e4699ec49a9beae1ea4845c6bab9314e4f84ac68742139d8c53"
 dependencies = [
+ "autocfg",
  "scopeguard",
 ]
 
@@ -804,7 +805,7 @@ dependencies = [
 
 [[package]]
 name = "lyretail"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -1136,7 +1137,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87f5ec2493a61ac0506c0f4199f99070cbe83857b0337006a30f3e6719b8ef58"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.1",
+ "parking_lot_core 0.9.2",
 ]
 
 [[package]]
@@ -1155,9 +1156,9 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.1"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28141e0cc4143da2443301914478dc976a61ffdb3f043058310c70df2fed8954"
+checksum = "995f667a6c822200b0433ac218e05582f0e2efa1b922a3fd2fbaadc5f87bab37"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1399,9 +1400,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.2.12"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae183fc1b06c149f0c1793e1eb447c8b04bfe46d48e9e48bfb8d2d7ed64ecf0"
+checksum = "62f25bc4c7e55e0b0b7a1d43fb893f4fa1361d0abe38b9ce4f323c2adfe6ef42"
 dependencies = [
  "bitflags",
 ]
@@ -1568,9 +1569,9 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9def91fd1e018fe007022791f865d0ccc9b3a0d5001e01aabb8b40e46000afb5"
+checksum = "eb703cfe953bccee95685111adeedb76fabe4e97549a58d16f03ea7b9367bb32"
 
 [[package]]
 name = "smallvec"
@@ -1802,6 +1803,7 @@ dependencies = [
  "futures-util",
  "pin-project-lite",
  "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -1905,9 +1907,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa31669fa42c09c34d94d8165dd2012e8ff3c66aca50f3bb226b68f216f2706c"
+checksum = "90442985ee2f57c9e1b548ee72ae842f4a9a20e3f417cc38dbc5dc684d9bb4ee"
 dependencies = [
  "lazy_static",
  "valuable",
@@ -1936,9 +1938,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.9"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e0ab7bdc962035a87fba73f3acca9b8a8d0034c2e6f60b84aeaaddddc155dce"
+checksum = "b9df98b037d039d03400d9dd06b0f8ce05486b5f25e9a2d7d36196e142ebbc52"
 dependencies = [
  "ansi_term",
  "sharded-slab",
@@ -2063,9 +2065,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
-version = "0.32.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3df6e476185f92a12c072be4a189a0210dcdcf512a1891d6dff9edb874deadc6"
+checksum = "5acdd78cb4ba54c0045ac14f62d8f94a03d10047904ae2a40afa1e99d8f70825"
 dependencies = [
  "windows_aarch64_msvc",
  "windows_i686_gnu",
@@ -2076,33 +2078,33 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.32.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8e92753b1c443191654ec532f14c199742964a061be25d77d7a96f09db20bf5"
+checksum = "17cffbe740121affb56fad0fc0e421804adf0ae00891205213b5cecd30db881d"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.32.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a711c68811799e017b6038e0922cb27a5e2f43a2ddb609fe0b6f3eeda9de615"
+checksum = "2564fde759adb79129d9b4f54be42b32c89970c18ebf93124ca8870a498688ed"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.32.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c11bb1a02615db74680b32a68e2d61f553cc24c4eb5b4ca10311740e44172"
+checksum = "9cd9d32ba70453522332c14d38814bceeb747d80b3958676007acadd7e166956"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.32.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c912b12f7454c6620635bbff3450962753834be2a594819bd5e945af18ec64bc"
+checksum = "cfce6deae227ee8d356d19effc141a509cc503dfd1f850622ec4b0f84428e1f4"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.32.0"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "504a2476202769977a040c6364301a3f65d0cc9e3fb08600b2bda150a0488316"
+checksum = "d19538ccc21819d01deaf88d6a17eae6596a12e9aafdbb97916fb49896d89de9"
 
 [[package]]
 name = "wyz"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,14 +8,17 @@ anyhow = "1.0.56"
 chrono = "0.4.1"
 clap = { version = "3.1.6", features = ["derive", "wrap_help"] }
 console-subscriber = "0.1.3"
-crossterm = "0.23"
+crossterm = { version = "0.23", features = ["event-stream"] }
 ctrlc = "3.2.1"
-duration-str = "0.3" 
-drain-flow = { git = "https://github.com/nharring-adjacent/drain-flow"}
+duration-str = "0.3"
+drain-flow = { git = "https://github.com/nharring-adjacent/drain-flow" }
+futures = "0.3.21"
+futures-core = "0.3"
 itertools = "0.10.3"
 joinery = "2.1.0"
 parking_lot = "0.12.0"
-tokio = {version = "1.8.3", features = ["full", "tracing"]}
+tokio = { version = "1.8.3", features = ["full", "tracing"] }
+tokio-util = { version = "0.7", features = ["rt"] }
 tracing = "0.1.32"
 tracing-subscriber = "0.3.9"
 tui = "0.17"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "lyretail"
-version = "0.2.0"
+description = "Lyretail is a command line log processing utility providing a summary view of the log lines seen and capable of operating on streaming or static data"
+version = "0.3.0"
 edition = "2021"
 
 [dependencies]

--- a/demo.sh
+++ b/demo.sh
@@ -6,4 +6,4 @@ if [ -z "$1" ]
 else
     FILE=$1
 fi
-RUST_LOG=error cargo run -- --interval 500ms --file <(while cat $FILE; do :; done)
+RUST_LOG=error cargo run -- --interval 500ms --source <(while cat $FILE; do :; done)

--- a/src/app.rs
+++ b/src/app.rs
@@ -44,8 +44,9 @@ impl LyreTail {
     //
     #[instrument]
     pub fn run(&self) {
-        let file = self.args.lock().file.clone();
+        let file = self.args.lock().source.clone();
         let drain = self.get_drain_ref();
+        let follow = self.args.lock().follow.clone();
         let io_runtime = Builder::new_current_thread().enable_all().build().unwrap();
         std::thread::spawn(move || {
             let mut reader = Box::pin(BufReader::new(stdin())) as Pin<Box<dyn AsyncBufRead>>;
@@ -57,7 +58,7 @@ impl LyreTail {
             io_runtime.block_on(async {
                 let mut buffer = String::new();
                 while let Ok(b) = reader.read_line(&mut buffer).await {
-                    if b == 0 {
+                    if b == 0 && !follow {
                         break;
                     }
                     let _ = drain.write().process_line(buffer.clone()).unwrap();

--- a/src/app.rs
+++ b/src/app.rs
@@ -31,7 +31,7 @@ impl LyreTail {
                     )))
                 })
                 .unwrap(),
-            args: args.clone(),
+            args,
         })
     }
 
@@ -46,7 +46,7 @@ impl LyreTail {
     pub fn run(&self) {
         let file = self.args.lock().source.clone();
         let drain = self.get_drain_ref();
-        let follow = self.args.lock().follow.clone();
+        let follow = self.args.lock().follow;
         let io_runtime = Builder::new_current_thread().enable_all().build().unwrap();
         std::thread::spawn(move || {
             let mut reader = Box::pin(BufReader::new(stdin())) as Pin<Box<dyn AsyncBufRead>>;

--- a/src/args.rs
+++ b/src/args.rs
@@ -11,7 +11,7 @@ pub(crate) struct Args {
     #[clap(short, long)]
     pub periodic: bool,
     /// The interval between updates
-    #[clap(parse(try_from_str = parse_chrono), short, long, default_value="10s")]
+    #[clap(parse(try_from_str = parse_chrono), short, long, default_value="1s")]
     pub interval: Duration,
     /// The source of input, read from stdin if not specified
     #[clap(short, long)]

--- a/src/args.rs
+++ b/src/args.rs
@@ -15,5 +15,8 @@ pub(crate) struct Args {
     pub interval: Duration,
     /// The source of input, read from stdin if not specified
     #[clap(short, long)]
-    pub file: Option<PathBuf>,
+    pub source: Option<PathBuf>,
+    /// Whether to watch files for changes when the end is reached
+    #[clap(short, long)]
+    pub follow: bool,
 }

--- a/src/args.rs
+++ b/src/args.rs
@@ -1,8 +1,8 @@
 use std::path::PathBuf;
 
+use chrono::Duration;
 use clap::Parser;
 use duration_str::parse_chrono;
-use chrono::Duration; 
 
 #[derive(Parser, Debug, Clone)]
 #[clap(author, version, about, long_about = None)]
@@ -15,5 +15,5 @@ pub(crate) struct Args {
     pub interval: Duration,
     /// The source of input, read from stdin if not specified
     #[clap(short, long)]
-    pub file: Option<PathBuf>
+    pub file: Option<PathBuf>,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use app::LyreTail;
 use clap::Parser;
 use drain_flow::SimpleDrain;
-use parking_lot::{RwLock, Mutex};
+use parking_lot::{Mutex, RwLock};
 use tracing::debug;
 
 use ui::Ui;

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,13 +3,16 @@ mod app;
 mod args;
 mod ui;
 
-use std::sync::Arc;
+use std::{io, sync::Arc};
 
 use app::LyreTail;
 use clap::Parser;
 use drain_flow::SimpleDrain;
 use parking_lot::{Mutex, RwLock};
-use tracing::debug;
+use tracing::{debug, Level};
+use tracing_subscriber::filter::LevelFilter;
+use tracing_subscriber::fmt::format::FmtSpan;
+use tracing_subscriber::prelude::*;
 
 use ui::Ui;
 
@@ -17,8 +20,17 @@ use crate::args::Args;
 
 #[tokio::main]
 async fn main() {
-    // console_subscriber::init();
-    tracing_subscriber::fmt::init();
+    tracing_subscriber::registry()
+        .with(console_subscriber::spawn())
+        .with(
+            tracing_subscriber::fmt::layer()
+                .with_ansi(false)
+                .with_span_events(FmtSpan::NONE)
+                .with_writer(io::stderr)
+                .compact()
+                .with_filter(LevelFilter::from_level(Level::WARN)),
+        )
+        .init();
 
     let args = Arc::new(Mutex::new(Args::parse()));
     debug!("got args");

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -16,9 +16,8 @@ use tui::{
 };
 
 use crossterm::{
-    event::{DisableMouseCapture, EnableMouseCapture},
     execute,
-    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
+    terminal::{EnterAlternateScreen, LeaveAlternateScreen},
 };
 
 use crate::app::LyreTail;


### PR DESCRIPTION
The core change here is the ability to select rows using the up and down arrows. Currently all this does is highlight the row but this is just laying the foundation for being able to inspect specific log lines and drill into the collected variables. 

That functionality is going to wait for `drain-flow` to get more sophisticated in how it handles examples and variables, the implementation of which was waiting on being ready to actually use that data.