### PR TITLE
Add cloudwatch logs support

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+rustflags = ["--cfg", "tokio_unstable"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Version 0.5.0
+
+## Features
+- Cloudwatch LogStream source, requires `aws` feature
+- Tracing integration improvement so `RUST_LOG` can be used to control level output
+- Flags to control log output to file or STDERR
+
+## Changes and improvements
+- Significant refactoring of input handling to make adding new sources easier
+- Migrated to `#[tokio::main]` and adopted `async-trait` to simplify using futures for concurrency
+
+## Bug Fixes
+- Key up/down logic was broken so only top/bottom rows could be selected, this is now fixed.
+
+## Deprecations
+- Update interval made no sense after making everything async

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1247,7 +1247,7 @@ dependencies = [
 
 [[package]]
 name = "lyretail"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -39,9 +39,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.56"
+version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4361135be9122e0870de935d7c439aef945b9f9ddd4199a553b5270b49c82a27"
+checksum = "08f9b8508dccb7687a1d6c4ce66b2b0ecef467c94667de27d8d7fe1f8d2a9cdc"
 
 [[package]]
 name = "arrayref"
@@ -111,10 +111,332 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
-name = "axum"
-version = "0.5.1"
+name = "aws-config"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47594e438a243791dba58124b6669561f5baa14cb12046641d8008bf035e5a25"
+checksum = "f91154572c69defdbe4ee7e7c86a0d1ad1f8c49655bedb7c6be61a7c1dc43105"
+dependencies = [
+ "aws-http",
+ "aws-sdk-sso",
+ "aws-sdk-sts",
+ "aws-smithy-async",
+ "aws-smithy-client",
+ "aws-smithy-http",
+ "aws-smithy-http-tower",
+ "aws-smithy-json",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "hex",
+ "http",
+ "hyper",
+ "ring",
+ "tokio",
+ "tower",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-endpoint"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "515bd0f038107827309daa28612941ff559e71a6e96335e336d4fdf4caffb34b"
+dependencies = [
+ "aws-smithy-http",
+ "aws-types",
+ "http",
+ "regex",
+ "tracing",
+]
+
+[[package]]
+name = "aws-http"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1378c2c2430a063076621ec8c6435cdbd97b3e053111aebb52c9333fc793f32c"
+dependencies = [
+ "aws-smithy-http",
+ "aws-smithy-types",
+ "aws-types",
+ "http",
+ "lazy_static",
+ "percent-encoding",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sdk-cloudwatchlogs"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdc817ab6e22901dca3adb374a1272979c37b227e46458745d7dfdf777f72f60"
+dependencies = [
+ "aws-endpoint",
+ "aws-http",
+ "aws-sig-auth",
+ "aws-smithy-async",
+ "aws-smithy-client",
+ "aws-smithy-http",
+ "aws-smithy-http-tower",
+ "aws-smithy-json",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "http",
+ "tokio-stream",
+ "tower",
+]
+
+[[package]]
+name = "aws-sdk-s3"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25e2c859c7420c8564b6eb964056abf508c10c0269cbd624ecc8c8de5c33446c"
+dependencies = [
+ "aws-endpoint",
+ "aws-http",
+ "aws-sig-auth",
+ "aws-sigv4",
+ "aws-smithy-async",
+ "aws-smithy-client",
+ "aws-smithy-eventstream",
+ "aws-smithy-http",
+ "aws-smithy-http-tower",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "bytes",
+ "http",
+ "md5",
+ "tokio-stream",
+ "tower",
+]
+
+[[package]]
+name = "aws-sdk-sso"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d74bff9a790eceb16a7825b11c4d9526fe6d3649349ba04beb5cb4770b7822b4"
+dependencies = [
+ "aws-endpoint",
+ "aws-http",
+ "aws-sig-auth",
+ "aws-smithy-async",
+ "aws-smithy-client",
+ "aws-smithy-http",
+ "aws-smithy-http-tower",
+ "aws-smithy-json",
+ "aws-smithy-types",
+ "aws-types",
+ "bytes",
+ "http",
+ "tokio-stream",
+ "tower",
+]
+
+[[package]]
+name = "aws-sdk-sts"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e879f3619e0b444218ab76d28364d57b81820ad792fd58088ab675237e4d7b5f"
+dependencies = [
+ "aws-endpoint",
+ "aws-http",
+ "aws-sig-auth",
+ "aws-smithy-async",
+ "aws-smithy-client",
+ "aws-smithy-http",
+ "aws-smithy-http-tower",
+ "aws-smithy-query",
+ "aws-smithy-types",
+ "aws-smithy-xml",
+ "aws-types",
+ "bytes",
+ "http",
+ "tower",
+]
+
+[[package]]
+name = "aws-sig-auth"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b44c7698294a89fabbadb538560ad34b6fdd26e926dee3c5e710928c3093fcf0"
+dependencies = [
+ "aws-sigv4",
+ "aws-smithy-eventstream",
+ "aws-smithy-http",
+ "aws-types",
+ "http",
+ "thiserror",
+ "tracing",
+]
+
+[[package]]
+name = "aws-sigv4"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fe0aee7539298b8447e1a60d2d6de329fb1619f116c5f488e0b3aa136d49696"
+dependencies = [
+ "aws-smithy-eventstream",
+ "aws-smithy-http",
+ "bytes",
+ "form_urlencoded",
+ "hex",
+ "http",
+ "once_cell",
+ "percent-encoding",
+ "regex",
+ "ring",
+ "time 0.3.9",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-async"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23dcbf7d119f514a627d236412626645c4378b126e30dc61db9de3e069fa1676"
+dependencies = [
+ "futures-util",
+ "pin-project-lite",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
+name = "aws-smithy-client"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "511ac6c65f2a89cfcd74fe78aa6d07216095a53cbaeab493b17f6df82cd65b86"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-http",
+ "aws-smithy-http-tower",
+ "aws-smithy-types",
+ "bytes",
+ "fastrand",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-rustls",
+ "lazy_static",
+ "pin-project",
+ "pin-project-lite",
+ "tokio",
+ "tower",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-eventstream"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703e7d99d80156d5a41a3996a985701650ccb0d5edaf441ca40bda199d34284e"
+dependencies = [
+ "aws-smithy-types",
+ "bytes",
+ "crc32fast",
+]
+
+[[package]]
+name = "aws-smithy-http"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d800c8684fa567cdf1abd9654c7997b2a887e7b06022938756193472ec7ec251"
+dependencies = [
+ "aws-smithy-eventstream",
+ "aws-smithy-types",
+ "bytes",
+ "bytes-utils",
+ "futures-core",
+ "http",
+ "http-body",
+ "hyper",
+ "once_cell",
+ "percent-encoding",
+ "pin-project",
+ "tokio",
+ "tokio-util 0.6.9",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-http-tower"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8017959786cce64e690214d303d062c97fcd38a68df7cb444255e534c9bbce49"
+dependencies = [
+ "aws-smithy-http",
+ "bytes",
+ "http",
+ "http-body",
+ "pin-project",
+ "tower",
+ "tracing",
+]
+
+[[package]]
+name = "aws-smithy-json"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3796e2a4a3b7d15db2fd5aec2de9220919332648f0a56a77b5c53caf4a9653fa"
+dependencies = [
+ "aws-smithy-types",
+]
+
+[[package]]
+name = "aws-smithy-query"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76694d1a2dacefa347b921c61bf64b5cc493a898971b3c18fa636ce1788ceabe"
+dependencies = [
+ "aws-smithy-types",
+ "urlencoding",
+]
+
+[[package]]
+name = "aws-smithy-types"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c7f957a2250cc0fa4ccf155e00aeac9a81f600df7cd4ecc910c75030e6534f5"
+dependencies = [
+ "itoa",
+ "num-integer",
+ "ryu",
+ "time 0.3.9",
+]
+
+[[package]]
+name = "aws-smithy-xml"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b01d77433f248d9a2b08f519b403d6aa8435bf144b5d8585862f8dd599eb843"
+dependencies = [
+ "thiserror",
+ "xmlparser",
+]
+
+[[package]]
+name = "aws-types"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "394d5c945b747ab3292b94509b78c91191aacfd1deacbcd58371d6f61f8be78a"
+dependencies = [
+ "aws-smithy-async",
+ "aws-smithy-client",
+ "aws-smithy-http",
+ "aws-smithy-types",
+ "http",
+ "rustc_version",
+ "tracing",
+ "zeroize",
+]
+
+[[package]]
+name = "axum"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4af7447fc1214c1f3a1ace861d0216a6c8bb13965b64bbad9650f375b67689a"
 dependencies = [
  "async-trait",
  "axum-core",
@@ -141,9 +463,9 @@ dependencies = [
 
 [[package]]
 name = "axum-core"
-version = "0.2.1"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a671c9ae99531afdd5d3ee8340b8da547779430689947144c140fc74a740244"
+checksum = "da31c0ed7b4690e2c78fe4b880d21cd7db04a346ebc658b4270251b695437f17"
 dependencies = [
  "async-trait",
  "bytes",
@@ -184,6 +506,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bumpalo"
+version = "3.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a45a46ab1f2412e53d3a0ade76ffad2025804294569aae387231a0cd6e0899"
+
+[[package]]
 name = "byteorder"
 version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -194,6 +522,16 @@ name = "bytes"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
+
+[[package]]
+name = "bytes-utils"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1934a3ef9cac8efde4966a92781e77713e1ba329f1d42e446c7d7eba340d8ef1"
+dependencies = [
+ "bytes",
+ "either",
+]
 
 [[package]]
 name = "cassowary"
@@ -222,22 +560,22 @@ dependencies = [
  "libc",
  "num-integer",
  "num-traits",
- "time",
+ "time 0.1.44",
  "winapi",
 ]
 
 [[package]]
 name = "clap"
-version = "3.1.8"
+version = "3.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71c47df61d9e16dc010b55dba1952a57d8c215dbb533fd13cdd13369aac73b1c"
+checksum = "85a35a599b11c089a7f49105658d089b8f2cf0882993c17daf6de15285c2c35d"
 dependencies = [
  "atty",
  "bitflags",
  "clap_derive",
+ "clap_lex",
  "indexmap",
  "lazy_static",
- "os_str_bytes",
  "strsim",
  "termcolor",
  "terminal_size",
@@ -258,6 +596,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_lex"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a37c35f1112dad5e6e0b1adaff798507497a18fceeb30cceb3bae7d1427b9213"
+dependencies = [
+ "os_str_bytes",
+]
+
+[[package]]
 name = "console-api"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -271,9 +618,9 @@ dependencies = [
 
 [[package]]
 name = "console-subscriber"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8bd6b23feb4180ccf20cefca9357262818443aafb7159b5e503d170d442a872"
+checksum = "8f21a16ee925aa9d2bad2e296beffd6c5b1bfaad50af509d305b8e7f23af20fb"
 dependencies = [
  "console-api",
  "crossbeam-channel",
@@ -298,6 +645,22 @@ name = "convert_case"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
+
+[[package]]
+name = "core-foundation"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
 
 [[package]]
 name = "crc32fast"
@@ -330,22 +693,6 @@ dependencies = [
 
 [[package]]
 name = "crossterm"
-version = "0.22.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c85525306c4291d1b73ce93c8acf9c339f9b213aef6c1d85c3830cbf1c16325c"
-dependencies = [
- "bitflags",
- "crossterm_winapi",
- "libc",
- "mio 0.7.14",
- "parking_lot 0.11.2",
- "signal-hook",
- "signal-hook-mio",
- "winapi",
-]
-
-[[package]]
-name = "crossterm"
 version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2102ea4f781910f8a5b98dd061f4c2023f479ce7bb1236330099ceb5a93cf17"
@@ -354,8 +701,8 @@ dependencies = [
  "crossterm_winapi",
  "futures-core",
  "libc",
- "mio 0.8.2",
- "parking_lot 0.12.0",
+ "mio",
+ "parking_lot",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -371,10 +718,19 @@ dependencies = [
 ]
 
 [[package]]
-name = "ctrlc"
-version = "3.2.1"
+name = "ct-logs"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a19c6cedffdc8c03a3346d723eb20bd85a13362bb96dc2ac000842c6381ec7bf"
+checksum = "c1a816186fa68d9e426e3cb4ae4dff1fcd8e4a2c34b781bf7a822574a0d0aac8"
+dependencies = [
+ "sct",
+]
+
+[[package]]
+name = "ctrlc"
+version = "3.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b37feaa84e6861e00a1f5e5aa8da3ee56d605c9992d33e082786754828e20865"
 dependencies = [
  "nix",
  "winapi",
@@ -385,6 +741,18 @@ name = "custom_derive"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef8ae57c4978a2acd8b869ce6b9ca1dfe817bff704c220209fdef2c0b75a01b9"
+
+[[package]]
+name = "dateparser"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81dcee48ba66b79ba92dab399f218228f98c5d601ca85127fbc1ad60caf237d8"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "lazy_static",
+ "regex",
+]
 
 [[package]]
 name = "derive_more"
@@ -402,7 +770,7 @@ dependencies = [
 [[package]]
 name = "drain-flow"
 version = "0.4.0-pre1"
-source = "git+https://github.com/nharring-adjacent/drain-flow#5ae96a0e8900a921632028cfb1179591931d7f72"
+source = "git+https://github.com/nharring-adjacent/drain-flow#dfb79f0a7019c2b21e78e9951b98d00a141f1bfa"
 dependencies = [
  "anyhow",
  "chrono",
@@ -414,7 +782,7 @@ dependencies = [
  "itertools",
  "joinery",
  "lazy_static",
- "parking_lot 0.12.0",
+ "parking_lot",
  "regex",
  "rksuid",
  "spectral",
@@ -459,6 +827,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "406ac2a8c9eedf8af9ee1489bee9e50029278a6456c740f7454cf8a158abc816"
 
 [[package]]
+name = "fastrand"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3fcf0cee53519c866c09b5de1f6c56ff9d647101f81c1964fa632e148896cdf"
+dependencies = [
+ "instant",
+]
+
+[[package]]
 name = "flate2"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -481,6 +858,16 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
+dependencies = [
+ "matches",
+ "percent-encoding",
+]
 
 [[package]]
 name = "fraction"
@@ -619,7 +1006,7 @@ dependencies = [
  "indexmap",
  "slab",
  "tokio",
- "tokio-util",
+ "tokio-util 0.7.1",
  "tracing",
 ]
 
@@ -661,10 +1048,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "http"
-version = "0.2.6"
+name = "hex"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31f4c6746584866f0feabcc69893c5b51beef3831656a968ed7ae254cdc4fd03"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "http"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff8670570af52249509a86f5e3e18a08c60b177071826898fde8997cf5f6bfbb"
 dependencies = [
  "bytes",
  "fnv",
@@ -690,9 +1083,9 @@ checksum = "0bfe8eed0a9285ef776bb792479ea3834e8b94e13d615c2f66d03dd50a435a29"
 
 [[package]]
 name = "httparse"
-version = "1.7.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6330e8a36bd8c859f3fa6d9382911fbb7147ec39807f63b923933a247240b9ba"
+checksum = "496ce29bb5a52785b44e0f7ca2847ae0bb839c9bd28f69acac9b99d461c0c04c"
 
 [[package]]
 name = "httpdate"
@@ -728,6 +1121,23 @@ dependencies = [
  "tower-service",
  "tracing",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f9f7a97316d44c0af9b0301e65010573a853a9fc97046d7331d7f6bc0fd5a64"
+dependencies = [
+ "ct-logs",
+ "futures-util",
+ "hyper",
+ "log",
+ "rustls",
+ "rustls-native-certs",
+ "tokio",
+ "tokio-rustls",
+ "webpki",
 ]
 
 [[package]]
@@ -783,6 +1193,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72167d68f5fce3b8655487b8038691a3c9984ee769590f93f2a631f4ad64e4f5"
 
 [[package]]
+name = "js-sys"
+version = "0.3.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "671a26f820db17c2a2750743f1dd03bafd15b98c9f30c7c2628c024c05d73397"
+dependencies = [
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -803,9 +1222,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.123"
+version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb691a747a7ab48abc15c5b42066eaafde10dc427e3b6ee2a1cf43db04c763bd"
+checksum = "5916d2ae698f6de9bfb891ad7a8d65c09d232dc58cc4ac433c7da3b2fd84bc2b"
 
 [[package]]
 name = "lock_api"
@@ -819,9 +1238,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.16"
+version = "0.4.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6389c490849ff5bc16be905ae24bc913a9c8892e19b2341dbc175e14c341c2b8"
+checksum = "abb12e687cfb44aa40f41fc3978ef76448f9b6038cad6aef4259d3c095a2382e"
 dependencies = [
  "cfg-if",
 ]
@@ -831,11 +1250,17 @@ name = "lyretail"
 version = "0.4.0"
 dependencies = [
  "anyhow",
+ "async-trait",
+ "aws-config",
+ "aws-sdk-cloudwatchlogs",
+ "aws-sdk-s3",
+ "aws-types",
  "chrono",
  "clap",
  "console-subscriber",
- "crossterm 0.23.2",
+ "crossterm",
  "ctrlc",
+ "dateparser",
  "drain-flow",
  "duration-str",
  "enum-kinds",
@@ -845,9 +1270,10 @@ dependencies = [
  "itertools",
  "joinery",
  "macro-attr",
- "parking_lot 0.12.0",
+ "parking_lot",
  "tokio",
- "tokio-util",
+ "tokio-stream",
+ "tokio-util 0.7.1",
  "tracing",
  "tracing-subscriber",
  "tui",
@@ -860,25 +1286,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "00e51c6f0e2bf862b01b3d784fc32b02feb248a69062c51fb0b6d14cd526cc2a"
 
 [[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
+name = "matches"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
+
+[[package]]
 name = "matchit"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73cbba799671b762df5a175adf59ce145165747bb891505c43d09aefbbf38beb"
 
 [[package]]
-name = "memchr"
-version = "2.4.1"
+name = "md5"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
-name = "memoffset"
-version = "0.6.5"
+name = "memchr"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
-dependencies = [
- "autocfg",
-]
+checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
 name = "mime"
@@ -899,19 +1337,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2b29bd4bc3f33391105ebee3589c19197c4271e3e5a9ec9bfe8127eeff8f082"
 dependencies = [
  "adler",
-]
-
-[[package]]
-name = "mio"
-version = "0.7.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8067b404fe97c70829f082dec8bcf4f71225d7eaea1d8645349cb76fa06205cc"
-dependencies = [
- "libc",
- "log",
- "miow",
- "ntapi",
- "winapi",
 ]
 
 [[package]]
@@ -939,15 +1364,13 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.23.1"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f866317acbd3a240710c63f065ffb1e4fd466259045ccb504130b7f668f35c6"
+checksum = "8f17df307904acd05aa8e32e97bb20f2a0df1728bbc2d771ae8f9a90463441e9"
 dependencies = [
  "bitflags",
- "cc",
  "cfg-if",
  "libc",
- "memoffset",
 ]
 
 [[package]]
@@ -1055,9 +1478,9 @@ dependencies = [
 
 [[package]]
 name = "num-integer"
-version = "0.1.44"
+version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2cc698a63b549a70bc047073d2949cce27cd1c7b0a4a862d08a8031bc2801db"
+checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
 dependencies = [
  "autocfg",
  "num-traits",
@@ -1065,9 +1488,9 @@ dependencies = [
 
 [[package]]
 name = "num-iter"
-version = "0.1.42"
+version = "0.1.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2021c8337a54d21aca0d59a92577a029af9431cb59b909b03252b9c164fad59"
+checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
 dependencies = [
  "autocfg",
  "num-integer",
@@ -1100,9 +1523,9 @@ dependencies = [
 
 [[package]]
 name = "num-traits"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a64b1ec5cda2586e284722486d802acf1f7dbdc623e2bfc57e65ca1cd099290"
+checksum = "578ede34cf02f8924ab9447f50c28075b4d3e5b269972345e7e0372b38c6cdcd"
 dependencies = [
  "autocfg",
 ]
@@ -1118,30 +1541,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_threads"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87f3e037eac156d1775da914196f0f37741a274155e34a0b7e427c35d2a2ecb9"
 
 [[package]]
+name = "openssl-probe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
 name = "os_str_bytes"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "parking_lot"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
-dependencies = [
- "instant",
- "lock_api",
- "parking_lot_core 0.8.5",
-]
 
 [[package]]
 name = "parking_lot"
@@ -1150,28 +1574,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87f5ec2493a61ac0506c0f4199f99070cbe83857b0337006a30f3e6719b8ef58"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.2",
+ "parking_lot_core",
 ]
 
 [[package]]
 name = "parking_lot_core"
-version = "0.8.5"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d76e8e1493bcac0d2766c42737f34458f1c8c50c0d23bcb24ea953affb273216"
-dependencies = [
- "cfg-if",
- "instant",
- "libc",
- "redox_syscall",
- "smallvec",
- "winapi",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "995f667a6c822200b0433ac218e05582f0e2efa1b922a3fd2fbaadc5f87bab37"
+checksum = "09a279cbf25cb0757810394fbc1e359949b59e348145c643a939a525692e6929"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1208,9 +1618,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e280fbe77cc62c91527259e9442153f4688736748d24660126286329742b4c6c"
+checksum = "e0a7ae3ac2f1173085d398531c705756c94a4c56843785df85a60c1a0afac116"
 
 [[package]]
 name = "pin-utils"
@@ -1402,10 +1812,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax",
+]
+
+[[package]]
 name = "regex-syntax"
 version = "0.6.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
+
+[[package]]
+name = "ring"
+version = "0.16.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
+dependencies = [
+ "cc",
+ "libc",
+ "once_cell",
+ "spin",
+ "untrusted",
+ "web-sys",
+ "winapi",
+]
 
 [[package]]
 name = "rksuid"
@@ -1449,6 +1883,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35edb675feee39aec9c99fa5ff985081995a06d594114ae14cbe797ad7b7a6d7"
+dependencies = [
+ "base64",
+ "log",
+ "ring",
+ "sct",
+ "webpki",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a07b7c1885bd8ed3831c289b7870b13ef46fe0e856d288c30d9cc17d75a2092"
+dependencies = [
+ "openssl-probe",
+ "rustls",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1461,31 +1920,74 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
 
 [[package]]
+name = "schannel"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75"
+dependencies = [
+ "lazy_static",
+ "winapi",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
 
 [[package]]
-name = "semver"
-version = "1.0.7"
+name = "sct"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d65bd28f48be7196d222d95b9243287f48d27aca604e08497513019ff0502cc4"
+checksum = "b362b83898e0e69f38515b82ee15aa80636befe47c3b6d3d89a911e78fc228ce"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
+name = "security-framework"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dc14f172faf8a0194a3aded622712b0de276821addc574fa54fc0a1167e10dc"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0160a13a177a45bfb43ce71c01580998474f556ad854dcbca936dd2841a5c556"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "semver"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cb243bdfdb5936c8dc3c45762a19d12ab4550cdc753bc247637d4ec35a040fd"
 
 [[package]]
 name = "serde"
-version = "1.0.136"
+version = "1.0.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce31e24b01e1e524df96f1c2fdd054405f8d7376249a5110886fb4b658484789"
+checksum = "61ea8d54c77f8315140a05f4c7237403bf38b72704d031543aa1d16abbf517d1"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.136"
+version = "1.0.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08597e7152fcd306f41838ed3e37be9eaeed2b61c42e2117266a554fab4662f9"
+checksum = "1f26faba0c3959972377d3b2d306ee9f71faee9714294e41bb777f83f88578be"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1494,9 +1996,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.79"
+version = "1.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e8d9fa5c3b304765ce1fd9c4c8a3de2c8db365a5b91be52f186efc675681d95"
+checksum = "9b7ce2b32a1aed03c558dc61a5cd328f15aff2dbc17daad8fb8af04d2100e15c"
 dependencies = [
  "itoa",
  "ryu",
@@ -1529,8 +2031,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29ad2e15f37ec9a6cc544097b78a1ec90001e9f71b81338ca39f430adaca99af"
 dependencies = [
  "libc",
- "mio 0.7.14",
- "mio 0.8.2",
+ "mio",
  "signal-hook",
 ]
 
@@ -1573,6 +2074,12 @@ checksum = "ae3c15181f4b14e52eeaac3efaeec4d2764716ce9c86da0c934c3e318649c5ba"
 dependencies = [
  "num 0.1.42",
 ]
+
+[[package]]
+name = "spin"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "static_assertions"
@@ -1618,9 +2125,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.91"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b683b2b825c8eef438b77c36a06dc262294da3d5a5813fac20da149241dcd44d"
+checksum = "7ff7c592601f11445996a06f8ad0c27f094a58857c2f89e97974ab9235b92c52"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1668,6 +2175,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "1.0.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd829fe32373d27f76265620b5309d0340cb8550f523c1dda251d6298069069a"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0396bc89e626244658bef819e22d0cc459e795a5ebe878e6ec336d1674a8d79a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "thread_local"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1688,18 +2215,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio"
-version = "1.17.0"
+name = "time"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2af73ac49756f3f7c01172e34a23e5d0216f6c32333757c2c61feb2bbff5a5ee"
+checksum = "c2702e08a7a860f005826c6815dcac101b19b5eb330c27fe4a5928fec1d20ddd"
+dependencies = [
+ "libc",
+ "num_threads",
+]
+
+[[package]]
+name = "tokio"
+version = "1.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce653fb475565de9f6fb0614b28bca8df2c430c0cf84bcd9c843f15de5414cc"
 dependencies = [
  "bytes",
  "libc",
  "memchr",
- "mio 0.8.2",
+ "mio",
  "num_cpus",
  "once_cell",
- "parking_lot 0.12.0",
+ "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
@@ -1730,12 +2267,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-rustls"
+version = "0.22.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6844de72e57df1980054b38be3a9f4702aba4858be64dd700181a8a6d0e1b6"
+dependencies = [
+ "rustls",
+ "tokio",
+ "webpki",
+]
+
+[[package]]
 name = "tokio-stream"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50145484efff8818b5ccd256697f36863f587da82cf8b409c53adf1e840798e3"
 dependencies = [
  "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e99e1983e5d376cd8eb4b66604d2e99e79f5bd988c3055891dcd8c9e2604cc0"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "log",
  "pin-project-lite",
  "tokio",
 ]
@@ -1779,7 +2341,7 @@ dependencies = [
  "prost-derive",
  "tokio",
  "tokio-stream",
- "tokio-util",
+ "tokio-util 0.7.1",
  "tower",
  "tower-layer",
  "tower-service",
@@ -1801,7 +2363,7 @@ dependencies = [
  "rand 0.8.5",
  "slab",
  "tokio",
- "tokio-util",
+ "tokio-util 0.7.1",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -1809,9 +2371,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.2.5"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aba3f3efabf7fb41fae8534fc20a817013dd1c12cb45441efb6c82e6556b4cd8"
+checksum = "e980386f06883cf4d0578d6c9178c81f68b45d77d00f2c2c1bc034b3439c2c56"
 dependencies = [
  "bitflags",
  "bytes",
@@ -1853,9 +2415,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.20"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e65ce065b4b5c53e73bb28912318cb8c9e9ad3921f1d669eb0e68b4c8143a2b"
+checksum = "cc6b8ad3567499f98a1db7a752b07a7c8c7c7c34c332ec00effb2b0027974b7c"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1884,9 +2446,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-log"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6923477a48e41c1951f1999ef8bb5a3023eb723ceadafe78ffb65dc366761e3"
+checksum = "78ddad33d2d10b1ed7eb9d1f518a5674713876e97e5bb9b7345a7984fbb4f922"
 dependencies = [
  "lazy_static",
  "log",
@@ -1900,9 +2462,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4bc28f93baff38037f64e6f43d34cfa1605f27a49c34e8a04c5e78b0babf2596"
 dependencies = [
  "ansi_term",
+ "lazy_static",
+ "matchers",
+ "regex",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
 ]
@@ -1915,13 +2481,13 @@ checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
 
 [[package]]
 name = "tui"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23ed0a32c88b039b73f1b6c5acbd0554bfa5b6be94467375fd947c4de3a02271"
+checksum = "96fe69244ec2af261bced1d9046a6fee6c8c2a6b0228e59e5ba39bc8ba4ed729"
 dependencies = [
  "bitflags",
  "cassowary",
- "crossterm 0.22.1",
+ "crossterm",
  "unicode-segmentation",
  "unicode-width",
 ]
@@ -1940,9 +2506,21 @@ checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
 
 [[package]]
 name = "unicode-xid"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+checksum = "957e51f3646910546462e67d5f7599b9e4fb8acdd304b087a6494730f9eebf04"
+
+[[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
+
+[[package]]
+name = "urlencoding"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68b90931029ab9b034b300b797048cf23723400aa757e8a2bfb9d748102f9821"
 
 [[package]]
 name = "valuable"
@@ -1979,6 +2557,80 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
+name = "wasm-bindgen"
+version = "0.2.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27370197c907c55e3f1a9fbe26f44e937fe6451368324e009cba39e139dc08ad"
+dependencies = [
+ "cfg-if",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e04185bfa3a779273da532f5025e33398409573f348985af9a1cbf3774d3f4"
+dependencies = [
+ "bumpalo",
+ "lazy_static",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17cae7ff784d7e83a2fe7611cfe766ecf034111b49deb850a3dc7699c08251f5"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99ec0dc7a4756fffc231aab1b9f2f578d23cd391390ab27f952ae0c9b3ece20b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.80"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d554b7f530dee5964d9a9468d95c1f8b8acae4f282807e7d27d4b03099a46744"
+
+[[package]]
+name = "web-sys"
+version = "0.3.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b17e741662c70c8bd24ac5c5b18de314a2c26c32bf8346ee1e6f53de919c283"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki"
+version = "0.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8e38c0608262c46d4a56202ebabdeb094cef7e560ca7a226c6bf055188aa4ea"
+dependencies = [
+ "ring",
+ "untrusted",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2011,9 +2663,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-sys"
-version = "0.34.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5acdd78cb4ba54c0045ac14f62d8f94a03d10047904ae2a40afa1e99d8f70825"
+checksum = "ea04155a16a59f9eab786fe12a4a450e75cdb175f9e0d80da1e17db09f55b8d2"
 dependencies = [
  "windows_aarch64_msvc",
  "windows_i686_gnu",
@@ -2024,36 +2676,48 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.34.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17cffbe740121affb56fad0fc0e421804adf0ae00891205213b5cecd30db881d"
+checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.34.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2564fde759adb79129d9b4f54be42b32c89970c18ebf93124ca8870a498688ed"
+checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.34.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cd9d32ba70453522332c14d38814bceeb747d80b3958676007acadd7e166956"
+checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.34.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfce6deae227ee8d356d19effc141a509cc503dfd1f850622ec4b0f84428e1f4"
+checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.34.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d19538ccc21819d01deaf88d6a17eae6596a12e9aafdbb97916fb49896d89de9"
+checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
 
 [[package]]
 name = "wyz"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
+
+[[package]]
+name = "xmlparser"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "114ba2b24d2167ef6d67d7d04c8cc86522b87f490025f39f0303b7db5bf5e3d8"
+
+[[package]]
+name = "zeroize"
+version = "1.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94693807d016b2f2d2e14420eb3bfcca689311ff775dcf113d74ea624b7cdf07"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,13 +6,18 @@ edition = "2021"
 license-file = "LICENSE"
 authors = ["Nicholas Harring <nharring@gmail.com>"]
 
+[features]
+aws = ["dep:aws-config", "dep:aws-sdk-cloudwatchlogs", "dep:aws-sdk-s3", "dep:aws-types"]
+
 [dependencies]
-anyhow = "1.0.56"
-chrono = "0.4.1"
-clap = { version = "3.1.6", features = ["derive", "wrap_help"] }
-console-subscriber = "0.1.3"
+anyhow = "1.0.57"
+async-trait = "0.1.53"
+chrono = "0.4.19"
+clap = { version = "3.1.15", features = ["derive", "wrap_help"] }
+console-subscriber = "0.1.5"
 crossterm = { version = "0.23", features = ["event-stream"] }
-ctrlc = "3.2.1"
+ctrlc = "3.2.2"
+dateparser = "0.1.6"
 duration-str = "0.3"
 drain-flow = { git = "https://github.com/nharring-adjacent/drain-flow" }
 enum_derive = "0.1"
@@ -23,8 +28,15 @@ itertools = "0.10.3"
 joinery = "2.1.0"
 macro-attr = "0.2"
 parking_lot = "0.12.0"
-tokio = { version = "1.8.3", features = ["full", "tracing"] }
+tokio = { version = "1.18.1", features = ["full", "tracing"] }
 tokio-util = { version = "0.7", features = ["rt"] }
-tracing = "0.1.32"
-tracing-subscriber = "0.3.9"
-tui = "0.17"
+tokio-stream = "0.1.8"
+tracing = "0.1.34"
+tracing-subscriber = {version = "0.3.11", features=["std", "env-filter"]}
+tui = "0.18.0"
+
+# The following are optional for supporting AWS ingest features
+aws-config = { version = "0.11.0", optional = true }
+aws-sdk-cloudwatchlogs = { version = "0.11.0", optional = true }
+aws-sdk-s3 = { version = "0.11.0", optional = true }
+aws-types = { version = "0.11.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lyretail"
 description = "Lyretail is a command line log processing utility providing a summary view of the log lines seen and capable of operating on streaming or static data"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 license-file = "LICENSE"
 authors = ["Nicholas Harring <nharring@gmail.com>"]

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Lyretail is different, requiring no upfront knowledge of stream contents and str
 
 ## Example usage
 This recording was generated using the demo.sh with no arguments on a Macbook air which has `/var/log/wifi.log`.
-[![asciicast](https://asciinema.org/a/481881.svg)](https://asciinema.org/a/481881)
+[![asciicast](https://asciinema.org/a/481881.png)](https://asciinema.org/a/481881?autoplay=1&preload=1)
 
 ## What's with the name?
 [Lyretail Coralfish](https://en.wikipedia.org/wiki/Sea_goldie) are members of the grouper (and sea bass!) family, and in my mind

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,14 @@
+reorder_imports = true
+group_imports = "StdExternalCrate"
+condense_wildcard_suffixes = true
+edition = "2021"
+force_multiline_blocks = true
+format_code_in_doc_comments = true
+format_generated_files = true
+imports_layout = "HorizontalVertical"
+match_block_trailing_comma = true
+imports_granularity = "Crate"
+normalize_comments = true
+normalize_doc_attributes = true
+reorder_impl_items = true
+use_field_init_shorthand = true

--- a/src/app.rs
+++ b/src/app.rs
@@ -70,17 +70,16 @@ impl LyreTail {
             #[cfg(feature = "aws")]
             crate::sources::SourceType::Cloudwatch => {
                 let args = self.args.lock();
-                let log_group = args
-                    .cloudwatch
-                    .clone()
-                    .expect("Must specify log stream when using cloudwatch sources");
+                let log_group = args.cloudwatch_log_group.clone();
+                let log_stream = args.cloudwatch_log_strean.clone();
                 let since = args.since.clone();
                 let until = args.until.clone();
                 let window = args.window.clone();
                 task::spawn(async move {
-                    let reader =
-                        aws::cloudwatch::CloudwatchReader::new(since, until, window, log_group)
-                            .await;
+                    let reader = aws::cloudwatch::CloudwatchReader::new(
+                        since, until, window, log_stream, log_group,
+                    )
+                    .await;
                     reader.read_logs(writer).await.unwrap();
                 });
             },

--- a/src/app.rs
+++ b/src/app.rs
@@ -8,19 +8,18 @@
 // Server Side Public License along with this program.
 // If not, see <http://www.mongodb.com/licensing/server-side-public-license>.
 
-use std::{pin::Pin, sync::Arc};
+use std::sync::Arc;
 
-use crate::args::Args;
 use anyhow::Error;
 use drain_flow::SimpleDrain;
 use parking_lot::{Mutex, RwLock};
-use tokio::{
-    fs::File,
-    io::{stdin, AsyncBufRead, AsyncBufReadExt, BufReader},
-    runtime::Builder,
-};
-use tracing::{debug, instrument};
+use tokio::task;
+use tokio::sync::mpsc;
+use tracing::instrument;
 
+#[cfg(feature = "aws")]
+use crate::sources::aws;
+use crate::{args::Args, sources::{file::FileReader, LogReader}};
 #[derive(Clone, Debug)]
 pub(crate) struct LyreTail {
     drain: Arc<RwLock<SimpleDrain>>,
@@ -28,7 +27,7 @@ pub(crate) struct LyreTail {
 }
 
 impl LyreTail {
-    #[instrument]
+    #[instrument(level = "trace", skip_all)]
     pub(crate) fn create_app(
         drain: Option<Arc<RwLock<SimpleDrain>>>,
         args: Arc<Mutex<Args>>,
@@ -46,35 +45,59 @@ impl LyreTail {
     }
 
     pub(crate) fn get_drain_ref(&self) -> Arc<RwLock<SimpleDrain>> {
-        debug!("cloning drain");
         self.drain.clone()
     }
 
-    // Run encapsulates the main input loop which processes lines and updates the drain
+    // init_input sets up the async background tasks which read and process lines from the source
     //
-    #[instrument]
-    pub fn run(&self) {
-        let file = self.args.lock().source.clone();
+    #[instrument(level = "trace", skip_all)]
+    pub(crate) async fn init_input(&self) {
         let drain = self.get_drain_ref();
+
         let follow = self.args.lock().follow;
-        let io_runtime = Builder::new_current_thread().enable_all().build().unwrap();
-        std::thread::spawn(move || {
-            let mut reader = Box::pin(BufReader::new(stdin())) as Pin<Box<dyn AsyncBufRead>>;
-            if let Some(file_path) = file {
-                reader = io_runtime.block_on(async {
-                    Box::pin(BufReader::new(File::open(file_path).await.unwrap()))
+        let (writer, reader) = mpsc::unbounded_channel::<String>();
+        let source_type = self.args.lock().source_type;
+        match source_type {
+            crate::sources::SourceType::File => {
+                let file = self.args.lock().file.clone().unwrap();
+                task::spawn(async move {
+                    let reader = FileReader::new(&file, follow);
+                    reader.read_logs(writer).await.unwrap();
                 });
             }
-            io_runtime.block_on(async {
-                let mut buffer = String::new();
-                while let Ok(b) = reader.read_line(&mut buffer).await {
-                    if b == 0 && !follow {
-                        break;
-                    }
-                    let _ = drain.write().process_line(buffer.clone()).unwrap();
-                    buffer.clear();
+            #[cfg(feature = "aws")]
+            crate::sources::SourceType::Cloudwatch => {
+                let args = self.args.lock();
+                let log_group = args
+                    .cloudwatch
+                    .clone()
+                    .expect("Must specify log stream when using cloudwatch sources");
+                let since = args.since.clone();
+                let until = args.until.clone();
+                let window = args.window.clone();
+                task::spawn(async move {
+                    let reader = aws::cloudwatch::CloudwatchReader::new(since, until, window, log_group).await;
+                    reader.read_logs(writer).await.unwrap();
+                });
+            }
+        };
+
+        task::spawn(async move { process_lines(drain, reader).await });
+    }
+}
+
+#[instrument(skip_all, level = "trace")]
+async fn process_lines(
+    drain: Arc<RwLock<SimpleDrain>>,
+    mut drain_reader: mpsc::UnboundedReceiver<String>,
+) -> Result<(), anyhow::Error> {
+    loop {
+        tokio::select! {
+            maybe_line = drain_reader.recv() => {
+                if let Some(line) = maybe_line {
+                    drain.write().process_line(line)?;
                 }
-            });
-        });
+            }
+        }
     }
 }

--- a/src/args.rs
+++ b/src/args.rs
@@ -51,13 +51,13 @@ impl Args {
     #[instrument(level = "trace")]
     pub fn validate(&self) -> Result<(), clap::ErrorKind> {
         match self.source_type {
-            SourceType::File => {}
+            SourceType::File => {},
             #[cfg(feature = "aws")]
             SourceType::Cloudwatch => {
                 if self.window.is_some() && (self.since.is_some() || self.until.is_some()) {
                     return Err(ErrorKind::ArgumentConflict);
                 }
-            }
+            },
         }
         Ok(())
     }

--- a/src/args.rs
+++ b/src/args.rs
@@ -29,10 +29,14 @@ pub(crate) struct Args {
     /// Whether to watch files for changes when the end is reached
     #[clap(long)]
     pub follow: bool,
-    /// Cloudwatch Logstream to read from
+    /// Cloudwatch Log Group to use
     #[cfg(feature = "aws")]
-    #[clap(short, long)]
-    pub cloudwatch: Option<String>,
+    #[clap(long)]
+    pub cloudwatch_log_group: String,
+    /// Cloudwatch Logstream to read from, if not supplied will attempt to read from all streams in group
+    #[cfg(feature = "aws")]
+    #[clap(long)]
+    pub cloudwatch_log_strean: Option<String>,
     /// Timestamp to start reading from
     #[cfg(feature = "aws")]
     #[clap(parse(try_from_str = dateparser), short, long)]

--- a/src/args.rs
+++ b/src/args.rs
@@ -10,23 +10,55 @@
 
 use std::path::PathBuf;
 
-use chrono::Duration;
-use clap::Parser;
+use chrono::{DateTime, Duration, Utc};
+use clap::{ErrorKind, Parser};
+use dateparser::parse as dateparser;
 use duration_str::parse_chrono;
+use tracing::instrument;
 
+use crate::sources::SourceType;
 #[derive(Parser, Debug, Clone)]
 #[clap(author, version, about, long_about = None)]
 pub(crate) struct Args {
-    /// Enable periodic printing of LogGroup information
-    #[clap(short, long)]
-    pub periodic: bool,
-    /// The interval between updates
-    #[clap(parse(try_from_str = parse_chrono), short, long, default_value="1s")]
-    pub interval: Duration,
-    /// The source of input, read from stdin if not specified
-    #[clap(short, long)]
-    pub source: Option<PathBuf>,
+    /// The type of source to read from
+    #[clap(arg_enum, long)]
+    pub source_type: SourceType,
+    /// File path to read from, default to stdin if source_type is file
+    #[clap(long)]
+    pub file: Option<PathBuf>,
     /// Whether to watch files for changes when the end is reached
-    #[clap(short, long)]
+    #[clap(long)]
     pub follow: bool,
+    /// Cloudwatch Logstream to read from
+    #[cfg(feature = "aws")]
+    #[clap(short, long)]
+    pub cloudwatch: Option<String>,
+    /// Timestamp to start reading from
+    #[cfg(feature = "aws")]
+    #[clap(parse(try_from_str = dateparser), short, long)]
+    pub since: Option<DateTime<Utc>>,
+    /// Timestamp to stop reading at
+    #[cfg(feature = "aws")]
+    #[clap(parse(try_from_str = dateparser), short, long)]
+    pub until: Option<DateTime<Utc>>,
+    #[cfg(feature = "aws")]
+    #[clap(parse(try_from_str = parse_chrono), short, long)]
+    pub window: Option<Duration>,
+}
+
+impl Args {
+    /// Run complex validation on arguments
+    #[instrument(level = "trace")]
+    pub fn validate(&self) -> Result<(), clap::ErrorKind> {
+        match self.source_type {
+            SourceType::File => {}
+            #[cfg(feature = "aws")]
+            SourceType::Cloudwatch => {
+                if self.window.is_some() && (self.since.is_some() || self.until.is_some()) {
+                    return Err(ErrorKind::ArgumentConflict);
+                }
+            }
+        }
+        Ok(())
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,15 +36,15 @@ async fn main() {
         .unwrap();
 
     tracing_subscriber::registry()
-        .with(console_subscriber::spawn())
         .with(
             tracing_subscriber::fmt::layer()
                 .with_ansi(false)
-                .with_span_events(FmtSpan::ACTIVE)
+                .with_span_events(FmtSpan::ENTER)
                 .with_writer(Arc::new(log_file))
                 .compact()
                 .with_filter(filter_layer),
         )
+        .with(console_subscriber::spawn())
         .init();
 
     let args_inner = Args::parse();

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,12 +23,10 @@ use clap::{CommandFactory, Parser};
 use drain_flow::SimpleDrain;
 use parking_lot::{Mutex, RwLock};
 use tracing::debug;
-use tracing_subscriber::fmt::format::FmtSpan;
-use tracing_subscriber::prelude::*;
-use tracing_subscriber::EnvFilter;
+use tracing_subscriber::{fmt::format::FmtSpan, prelude::*, EnvFilter};
+use ui::Ui;
 
 use crate::args::Args;
-use ui::Ui;
 
 #[tokio::main]
 async fn main() {
@@ -52,11 +50,11 @@ async fn main() {
     let args_inner = Args::parse();
     debug!("got args");
     match args_inner.validate() {
-        Ok(_) => {}
+        Ok(_) => {},
         Err(e) => {
             let mut cmd = Args::command();
             cmd.error(e, "Incompatible arguments provided").exit();
-        }
+        },
     };
     debug!("validated args");
     let args = Arc::new(Mutex::new(args_inner));

--- a/src/sources/aws/cloudwatch.rs
+++ b/src/sources/aws/cloudwatch.rs
@@ -1,3 +1,13 @@
+// Copyright Nicholas Harring. All rights reserved.
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the Server Side Public License, version 1, as published by MongoDB, Inc.
+// This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+// without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+// See the Server Side Public License for more details. You should have received a copy of the
+// Server Side Public License along with this program.
+// If not, see <http://www.mongodb.com/licensing/server-side-public-license>.
+
 use async_trait::async_trait;
 use aws_sdk_cloudwatchlogs::Client;
 use chrono::{DateTime, Duration, Utc};

--- a/src/sources/aws/cloudwatch.rs
+++ b/src/sources/aws/cloudwatch.rs
@@ -28,7 +28,7 @@ impl CloudwatchReader {
                     .expect("valid duration should not wrap");
                 let end = Utc::now();
                 (start, end)
-            }
+            },
             None => {
                 let start = if let None = since {
                     // default to 1 hour ago
@@ -45,23 +45,20 @@ impl CloudwatchReader {
                     until.unwrap().to_owned()
                 };
                 (start, end)
-            }
+            },
         };
         CloudwatchReader {
             client: aws_sdk_cloudwatchlogs::Client::new(&client_config),
             since: start,
             until: end,
-            log_stream
+            log_stream,
         }
     }
 }
 
 #[async_trait]
 impl LogReader for CloudwatchReader {
-    async fn read_logs(
-        &self,
-        lines: mpsc::UnboundedSender<String>,
-    ) -> Result<(), anyhow::Error> {
+    async fn read_logs(&self, lines: mpsc::UnboundedSender<String>) -> Result<(), anyhow::Error> {
         let mut event_fetcher = self
             .client
             .get_log_events()

--- a/src/sources/aws/cloudwatch.rs
+++ b/src/sources/aws/cloudwatch.rs
@@ -1,0 +1,89 @@
+use async_trait::async_trait;
+use aws_sdk_cloudwatchlogs::Client;
+use chrono::{DateTime, Duration, Utc};
+use tokio::sync::mpsc;
+use tokio_stream::StreamExt;
+
+use crate::sources::LogReader;
+#[derive(Debug, Clone)]
+pub(crate) struct CloudwatchReader {
+    client: Client,
+    log_stream: String,
+    since: DateTime<Utc>,
+    until: DateTime<Utc>,
+}
+
+impl CloudwatchReader {
+    pub async fn new(
+        since: Option<DateTime<Utc>>,
+        until: Option<DateTime<Utc>>,
+        window: Option<Duration>,
+        log_stream: String,
+    ) -> CloudwatchReader {
+        let client_config = Box::new(aws_config::load_from_env().await);
+        let (start, end) = match window {
+            Some(window) => {
+                let start = Utc::now()
+                    .checked_sub_signed(window)
+                    .expect("valid duration should not wrap");
+                let end = Utc::now();
+                (start, end)
+            }
+            None => {
+                let start = if let None = since {
+                    // default to 1 hour ago
+                    Utc::now()
+                        .checked_sub_signed(Duration::hours(1))
+                        .expect("1 hour ago does not wrap")
+                } else {
+                    since.unwrap().to_owned()
+                };
+                let end = if let None = until {
+                    // default to now
+                    Utc::now()
+                } else {
+                    until.unwrap().to_owned()
+                };
+                (start, end)
+            }
+        };
+        CloudwatchReader {
+            client: aws_sdk_cloudwatchlogs::Client::new(&client_config),
+            since: start,
+            until: end,
+            log_stream
+        }
+    }
+}
+
+#[async_trait]
+impl LogReader for CloudwatchReader {
+    async fn read_logs(
+        &self,
+        lines: mpsc::UnboundedSender<String>,
+    ) -> Result<(), anyhow::Error> {
+        let mut event_fetcher = self
+            .client
+            .get_log_events()
+            .log_stream_name(self.log_stream.clone())
+            .set_start_time(Some(self.since.timestamp_millis()))
+            .set_end_time(Some(self.until.timestamp_millis()))
+            .start_from_head(true)
+            .into_paginator()
+            .send();
+
+        while let Some(event) = event_fetcher.next().await {
+            if let Ok(log_events) = event {
+                for log_event in log_events.events().unwrap_or_default() {
+                    lines.send(
+                        log_event
+                            .message()
+                            .expect("log events have messages")
+                            .to_string(),
+                    )?;
+                }
+            }
+        }
+        Ok(())
+    }
+}

--- a/src/sources/aws/mod.rs
+++ b/src/sources/aws/mod.rs
@@ -1,1 +1,11 @@
+// Copyright Nicholas Harring. All rights reserved.
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the Server Side Public License, version 1, as published by MongoDB, Inc.
+// This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+// without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+// See the Server Side Public License for more details. You should have received a copy of the
+// Server Side Public License along with this program.
+// If not, see <http://www.mongodb.com/licensing/server-side-public-license>.
+
 pub(crate) mod cloudwatch;

--- a/src/sources/aws/mod.rs
+++ b/src/sources/aws/mod.rs
@@ -1,0 +1,1 @@
+pub(crate) mod cloudwatch;

--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -1,10 +1,11 @@
 use std::path::PathBuf;
 
 use async_trait::async_trait;
-use tokio::fs::File;
-use tokio::io::AsyncBufReadExt;
-use tokio::io::BufReader;
-use tokio::sync::mpsc;
+use tokio::{
+    fs::File,
+    io::{AsyncBufReadExt, BufReader},
+    sync::mpsc,
+};
 use tracing::instrument;
 
 use crate::sources::LogReader;
@@ -15,7 +16,7 @@ pub(crate) struct FileReader<'a> {
 }
 
 impl<'a> FileReader<'a> {
-    #[instrument(level="trace")]
+    #[instrument(level = "trace")]
     pub(crate) fn new(file: &'a PathBuf, follow: bool) -> Self {
         Self { file, follow }
     }
@@ -23,7 +24,7 @@ impl<'a> FileReader<'a> {
 
 #[async_trait]
 impl LogReader for FileReader<'_> {
-    #[instrument(level="trace", skip_all)]
+    #[instrument(level = "trace", skip_all)]
     async fn read_logs(
         &self,
         drain_writer: mpsc::UnboundedSender<String>,

--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -1,3 +1,13 @@
+// Copyright Nicholas Harring. All rights reserved.
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the Server Side Public License, version 1, as published by MongoDB, Inc.
+// This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+// without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+// See the Server Side Public License for more details. You should have received a copy of the
+// Server Side Public License along with this program.
+// If not, see <http://www.mongodb.com/licensing/server-side-public-license>.
+
 use std::path::PathBuf;
 
 use async_trait::async_trait;

--- a/src/sources/file.rs
+++ b/src/sources/file.rs
@@ -1,0 +1,42 @@
+use std::path::PathBuf;
+
+use async_trait::async_trait;
+use tokio::fs::File;
+use tokio::io::AsyncBufReadExt;
+use tokio::io::BufReader;
+use tokio::sync::mpsc;
+use tracing::instrument;
+
+use crate::sources::LogReader;
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) struct FileReader<'a> {
+    file: &'a PathBuf,
+    follow: bool,
+}
+
+impl<'a> FileReader<'a> {
+    #[instrument(level="trace")]
+    pub(crate) fn new(file: &'a PathBuf, follow: bool) -> Self {
+        Self { file, follow }
+    }
+}
+
+#[async_trait]
+impl LogReader for FileReader<'_> {
+    #[instrument(level="trace", skip_all)]
+    async fn read_logs(
+        &self,
+        drain_writer: mpsc::UnboundedSender<String>,
+    ) -> Result<(), anyhow::Error> {
+        let mut reader = Box::pin(BufReader::new(File::open(self.file).await.unwrap()));
+        let mut buffer = String::new();
+        while let Ok(b) = reader.read_line(&mut buffer).await {
+            if b == 0 && !self.follow {
+                break;
+            }
+            drain_writer.send(buffer.clone())?;
+            buffer.clear();
+        }
+        Ok(())
+    }
+}

--- a/src/sources/mod.rs
+++ b/src/sources/mod.rs
@@ -1,3 +1,13 @@
+// Copyright Nicholas Harring. All rights reserved.
+//
+// This program is free software: you can redistribute it and/or modify it under
+// the terms of the Server Side Public License, version 1, as published by MongoDB, Inc.
+// This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+// without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+// See the Server Side Public License for more details. You should have received a copy of the
+// Server Side Public License along with this program.
+// If not, see <http://www.mongodb.com/licensing/server-side-public-license>.
+
 #[cfg(feature = "aws")]
 pub(crate) mod aws;
 

--- a/src/sources/mod.rs
+++ b/src/sources/mod.rs
@@ -1,0 +1,21 @@
+#[cfg(feature = "aws")]
+pub(crate) mod aws;
+
+pub(crate) mod file;
+
+use async_trait::async_trait;
+use clap::ArgEnum;
+use tokio::sync::mpsc;
+
+/// Supported source types
+#[derive(ArgEnum, Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub(crate) enum SourceType {
+    File,
+    #[cfg(feature = "aws")]
+    Cloudwatch,
+}
+
+#[async_trait]
+pub(crate) trait LogReader {
+    async fn read_logs(&self, drain_writer: mpsc::UnboundedSender<String>) -> Result<(), anyhow::Error>;
+}

--- a/src/sources/mod.rs
+++ b/src/sources/mod.rs
@@ -17,5 +17,8 @@ pub(crate) enum SourceType {
 
 #[async_trait]
 pub(crate) trait LogReader {
-    async fn read_logs(&self, drain_writer: mpsc::UnboundedSender<String>) -> Result<(), anyhow::Error>;
+    async fn read_logs(
+        &self,
+        drain_writer: mpsc::UnboundedSender<String>,
+    ) -> Result<(), anyhow::Error>;
 }

--- a/src/ui/base.rs
+++ b/src/ui/base.rs
@@ -25,9 +25,8 @@ use tui::{
     Frame,
 };
 
-use crate::app::LyreTail;
-
 use super::UiState;
+use crate::app::LyreTail;
 
 #[derive(Clone, Debug)]
 pub(crate) struct BaseTable {
@@ -112,7 +111,7 @@ impl<'a> BaseTable {
                         self.state.select(Some(0));
                     }
                     return UiState::Base;
-                }
+                },
                 KeyCode::Down => {
                     debug!("key down handler");
                     let selected = self.state.selected();
@@ -128,11 +127,11 @@ impl<'a> BaseTable {
                     }
 
                     return UiState::Base;
-                }
+                },
                 KeyCode::Esc => {
                     debug!("key esc");
                     return UiState::Exiting;
-                }
+                },
                 KeyCode::Char(c) => {
                     // Ctrl-C, q and Esc all trigger exit
                     if (c == 'c' && key.modifiers.contains(KeyModifiers::CONTROL)) || c == 'q' {
@@ -141,7 +140,7 @@ impl<'a> BaseTable {
                     } else {
                         return UiState::Base;
                     }
-                }
+                },
                 KeyCode::Enter => {
                     if let Some(selected) = self.state.selected() {
                         let lg = self.get_selected(selected);
@@ -149,11 +148,11 @@ impl<'a> BaseTable {
                     } else {
                         return UiState::Base;
                     }
-                }
+                },
                 u => {
                     warn!(?u, "Unknown key");
                     return UiState::Base;
-                }
+                },
             }
         }
         UiState::Base

--- a/src/ui/log_group.rs
+++ b/src/ui/log_group.rs
@@ -55,7 +55,7 @@ impl LogGroupTab {
             match key.code {
                 KeyCode::Esc => {
                     return UiState::Base;
-                }
+                },
                 KeyCode::Char(c) => {
                     // Ctrl-C, q and Esc all trigger exit
                     if (c == 'c' && key.modifiers.contains(KeyModifiers::CONTROL)) || c == 'q' {
@@ -64,10 +64,10 @@ impl LogGroupTab {
                     } else {
                         return current;
                     }
-                }
+                },
                 _ => {
                     return current;
-                }
+                },
             }
         }
         current

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -8,31 +8,31 @@
 // Server Side Public License along with this program.
 // If not, see <http://www.mongodb.com/licensing/server-side-public-license>.
 
-use crossterm::event::{self, Event};
-use crossterm::terminal::{disable_raw_mode, enable_raw_mode};
-use drain_flow::log_group::LogGroup;
-use tui::backend::Backend;
-use tui::Frame;
-
-use std::io::Stdout;
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::{io::stdout, sync::Arc};
+use std::{
+    io::{stdout, Stdout},
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc,
+    },
+};
 
 use anyhow::Error;
 use chrono::Duration;
-
-use tracing::{debug, instrument, warn};
-use tui::{backend::CrosstermBackend, Terminal};
-
 use crossterm::{
+    event::{self, Event},
     execute,
-    terminal::{EnterAlternateScreen, LeaveAlternateScreen},
+    terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
+};
+use drain_flow::log_group::LogGroup;
+use tracing::{debug, instrument, warn};
+use tui::{
+    backend::{Backend, CrosstermBackend},
+    Frame,
+    Terminal,
 };
 
+use self::{base::BaseTable, log_group::LogGroupTab};
 use crate::app::LyreTail;
-
-use self::base::BaseTable;
-use self::log_group::LogGroupTab;
 
 mod base;
 mod log_group;
@@ -75,12 +75,13 @@ impl<'a> Ui {
         })
     }
 
-    #[instrument(level="trace", skip(self))]
+    #[instrument(level = "trace", skip(self))]
     fn trigger_exit(&self) {
         warn!("Triggering program exit");
         self.stopping.store(true, Ordering::SeqCst);
     }
-    #[instrument(level="trace", skip(self))]
+
+    #[instrument(level = "trace", skip(self))]
     pub(crate) fn run_ui(&mut self) -> Result<(), Error> {
         loop {
             if self.stopping.load(Ordering::SeqCst) {
@@ -96,7 +97,7 @@ impl<'a> Ui {
                     } else {
                         UiState::Base
                     }
-                }
+                },
                 UiState::LogGroup(log_group) => {
                     self.log_group = Some(log_group.clone());
                     let lg_view = LogGroupTab::new(log_group.clone());
@@ -107,11 +108,11 @@ impl<'a> Ui {
                     } else {
                         UiState::LogGroup(log_group.clone())
                     }
-                }
+                },
                 UiState::Exiting => {
                     self.stopping.store(true, Ordering::SeqCst);
                     UiState::Exiting
-                }
+                },
             };
         }
         let _rs = debug!("restoring terminal");


### PR DESCRIPTION
A bunch of refactoring and cleanup around sources to allow for adding Cloudwatch Logs support in a primitive form behind `features=aws`. 