### PR TITLE
Implement Dioxus components and new desktop binary

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ itertools = "0.10.3"
 joinery = "2.1.0"
 macro-attr = "0.2"
 parking_lot = "0.12.0"
+rfd = "0.11"
 tokio = { version = "1.18.1", features = ["full", "tracing"] }
 tokio-util = { version = "0.7", features = ["rt"] }
 tokio-stream = "0.1.8"
@@ -43,3 +44,7 @@ aws-types = { version = "0.11.0", optional = true }
 dioxus = "0.4"
 dioxus-desktop = "0.4"
 dioxus-web = "0.4"
+
+[[bin]]
+name = "dioxus-desktop"
+path = "src/bin/dioxus_desktop.rs"

--- a/src/bin/dioxus_desktop.rs
+++ b/src/bin/dioxus_desktop.rs
@@ -1,12 +1,11 @@
-use dioxus::prelude::*;
 use dioxus_desktop::Config;
 use rfd::FileDialog;
 use std::fs::File;
 use std::io::{BufRead, BufReader};
 use std::path::PathBuf;
 
-use lyratail::dioxus_ui::app::{App, AppProps};
-use lyratail::dioxus_ui::base_table::LogGroupSummaryProps;
+use lyretail::dioxus_ui::app::{App, AppProps};
+use lyretail::dioxus_ui::base_table::LogGroupSummaryProps;
 
 fn open_file_dialog() -> Option<PathBuf> {
     FileDialog::new()
@@ -49,6 +48,6 @@ fn main() {
     dioxus_desktop::launch_with_props(
         App,
         AppProps { log_groups: log_groups_data },
-        Config::new().with_window(dioxus_desktop::WindowBuilder::new().with_title("Lyratail Log Analyzer Desktop"))
+        Config::new().with_window(dioxus_desktop::WindowBuilder::new().with_title("Lyretail Log Analyzer Desktop"))
     );
 }

--- a/src/bin/dioxus_desktop.rs
+++ b/src/bin/dioxus_desktop.rs
@@ -1,0 +1,54 @@
+use dioxus::prelude::*;
+use dioxus_desktop::Config;
+use rfd::FileDialog;
+use std::fs::File;
+use std::io::{BufRead, BufReader};
+use std::path::PathBuf;
+
+use lyratail::dioxus_ui::app::{App, AppProps};
+use lyratail::dioxus_ui::base_table::LogGroupSummaryProps;
+
+fn open_file_dialog() -> Option<PathBuf> {
+    FileDialog::new()
+        .add_filter("Text files", &["txt", "log"])
+        .pick_file()
+}
+
+fn read_and_process_file(file_path: PathBuf) -> std::io::Result<Vec<LogGroupSummaryProps>> {
+    let file = File::open(file_path)?;
+    let reader = BufReader::new(file);
+    let line_count = reader.lines().count();
+
+    // Placeholder processing: create one summary item based on line count
+    Ok(vec![LogGroupSummaryProps {
+        id: "file_summary".to_string(),
+        event_summary: format!("File has {} lines", line_count),
+        quantity_seen: line_count as u32, // Assuming quantity_seen is u32
+    }])
+}
+
+fn main() {
+    let log_groups_data = match open_file_dialog() {
+        Some(path) => {
+            match read_and_process_file(path) {
+                Ok(data) => data,
+                Err(e) => {
+                    // Simple error handling: print to console and use empty data
+                    eprintln!("Error reading or processing file: {}", e);
+                    vec![]
+                }
+            }
+        }
+        None => {
+            // No file selected, use empty data
+            println!("No file selected.");
+            vec![]
+        }
+    };
+
+    dioxus_desktop::launch_with_props(
+        App,
+        AppProps { log_groups: log_groups_data },
+        Config::new().with_window(dioxus_desktop::WindowBuilder::new().with_title("Lyratail Log Analyzer Desktop"))
+    );
+}

--- a/src/dioxus_ui/app.rs
+++ b/src/dioxus_ui/app.rs
@@ -3,7 +3,8 @@
 
 use dioxus::prelude::*;
 use crate::dioxus_ui::base_table::{BaseTable, LogGroupSummaryProps};
-use crate::dioxus_ui::log_group_view::{LogGroupView, LogGroupDetailProps};
+// Import LogGroupViewProps alongside LogGroupView and LogGroupDetailProps
+use crate::dioxus_ui::log_group_view::{LogGroupView, LogGroupDetailProps, LogGroupViewProps};
 
 // Define a simple enum for the view state, similar to the TUI's UiState
 // We won't implement the logic to switch states yet.
@@ -18,13 +19,7 @@ pub struct AppProps {
 }
 
 // This is the main application component for the Dioxus UI.
-// It's not launched, just defined.
 pub fn App(cx: Scope<AppProps>) -> Element {
-    // For now, let's just show the BaseTable with sample data
-    // and the LogGroupView with sample data or as empty.
-    // In a real app, state would determine which view is more prominent
-    // or if LogGroupView is shown at all.
-
     // Sample data for LogGroupView is kept for now.
     let selected_log_group_sample = LogGroupDetailProps {
         id: "group_1_detail".to_string(),
@@ -32,15 +27,23 @@ pub fn App(cx: Scope<AppProps>) -> Element {
         occurrences: 10,
     };
 
+    // Explicitly create LogGroupViewProps
+    let props_for_selected_view = LogGroupViewProps {
+        selected_log_group: Some(selected_log_group_sample.clone()) // Clone sample data for ownership
+    };
+    let props_for_empty_view = LogGroupViewProps {
+        selected_log_group: None
+    };
+
     cx.render(rsx! {
         div {
             h1 { "LyreTail - Dioxus UI Shell" }
             BaseTable { log_groups: cx.props.log_groups.clone() }
             hr {}
-            // For LogGroupView, we use selected_log_group prop name
-            LogGroupView { selected_log_group: Some(selected_log_group_sample) }
+            // Use spread syntax for props
+            LogGroupView { ..props_for_selected_view }
             hr {}
-            LogGroupView { selected_log_group: None } // Example of no log group selected
+            LogGroupView { ..props_for_empty_view }
         }
     })
 }

--- a/src/dioxus_ui/app.rs
+++ b/src/dioxus_ui/app.rs
@@ -12,27 +12,20 @@ pub enum DioxusUiState {
     LogGroupSelected(LogGroupDetailProps),
 }
 
+#[derive(Props, PartialEq, Clone)]
+pub struct AppProps {
+    pub log_groups: Vec<LogGroupSummaryProps>,
+}
+
 // This is the main application component for the Dioxus UI.
 // It's not launched, just defined.
-pub fn App(cx: Scope) -> Element {
+pub fn App(cx: Scope<AppProps>) -> Element {
     // For now, let's just show the BaseTable with sample data
     // and the LogGroupView with sample data or as empty.
     // In a real app, state would determine which view is more prominent
     // or if LogGroupView is shown at all.
 
-    let sample_log_groups = vec![
-        LogGroupSummaryProps {
-            id: "group_1".to_string(),
-            event_summary: "User logged in".to_string(),
-            quantity_seen: 10,
-        },
-        LogGroupSummaryProps {
-            id: "group_2".to_string(),
-            event_summary: "File not found".to_string(),
-            quantity_seen: 5,
-        },
-    ];
-
+    // Sample data for LogGroupView is kept for now.
     let selected_log_group_sample = LogGroupDetailProps {
         id: "group_1_detail".to_string(),
         template: "User <*> logged in from <*>".to_string(),
@@ -42,11 +35,12 @@ pub fn App(cx: Scope) -> Element {
     cx.render(rsx! {
         div {
             h1 { "LyreTail - Dioxus UI Shell" }
-            BaseTable { log_groups: sample_log_groups }
+            BaseTable { log_groups: cx.props.log_groups.clone() }
             hr {}
-            LogGroupView { log_group: selected_log_group_sample } // Corrected based on previous learning
+            // For LogGroupView, we use selected_log_group prop name
+            LogGroupView { selected_log_group: Some(selected_log_group_sample) }
             hr {}
-            LogGroupView { } // Example of no log group selected
+            LogGroupView { selected_log_group: None } // Example of no log group selected
         }
     })
 }

--- a/src/dioxus_ui/base_table.rs
+++ b/src/dioxus_ui/base_table.rs
@@ -8,7 +8,7 @@ use dioxus::prelude::*;
 pub struct LogGroupSummaryProps {
     pub id: String,
     pub event_summary: String,
-    pub quantity_seen: usize,
+    pub quantity_seen: u32,
 }
 
 #[derive(Props, PartialEq, Clone)]
@@ -21,29 +21,25 @@ pub struct BaseTableProps {
 
 pub fn BaseTable(cx: Scope<BaseTableProps>) -> Element {
     cx.render(rsx! {
-        div {
-            h2 { "Log Groups (Dioxus)" }
-            table {
-                thead {
-                    tr {
-                        th { "ID" }
-                        th { "Event" }
-                        th { "Quantity Seen" }
-                    }
-                }
-                tbody {
-                    {cx.props.log_groups.iter().map(|lg| rsx! {
-                        tr {
-                            key: "{lg.id}",
-                            td { "{lg.id}" }
-                            td { "{lg.event_summary}" }
-                            td { "{lg.quantity_seen}" }
-                        }
-                    })}
+        table {
+            class: "table-auto w-full",
+            thead {
+                tr {
+                    th { class: "px-4 py-2", "ID" }
+                    th { class: "px-4 py-2", "Event Summary" }
+                    th { class: "px-4 py-2", "Quantity Seen" }
                 }
             }
-            // Placeholder for future interactions, e.g., keyboard navigation
-            // For now, no interactive elements are implemented.
+            tbody {
+                {cx.props.log_groups.iter().map(|log_group| rsx! {
+                    tr {
+                        key: "{log_group.id}",
+                        td { class: "border px-4 py-2", "{log_group.id}" }
+                        td { class: "border px-4 py-2", "{log_group.event_summary}" }
+                        td { class: "border px-4 py-2", "{log_group.quantity_seen}" }
+                    }
+                })}
+            }
         }
     })
 }

--- a/src/dioxus_ui/log_group_view.rs
+++ b/src/dioxus_ui/log_group_view.rs
@@ -45,8 +45,19 @@ fn _example_usage(cx: Scope) -> Element {
         template: "User <*> logged in from <*>".to_string(),
         occurrences: 10, // Note: This example occurrence will be u32
     };
+
+    // Explicitly create LogGroupViewProps for the example
+    let props_for_selected_example = LogGroupViewProps {
+        selected_log_group: Some(sample_detail.clone()) // Clone sample data
+    };
+    let props_for_empty_example = LogGroupViewProps {
+        selected_log_group: None
+    };
+
     cx.render(rsx! {
-        LogGroupView { selected_log_group: Some(sample_detail) }
-        LogGroupView { selected_log_group: None }
+        // Use spread syntax for props in the example
+        LogGroupView { ..props_for_selected_example }
+        br {} // Added a line break for visual separation in example output
+        LogGroupView { ..props_for_empty_example }
     })
 }

--- a/src/dioxus_ui/log_group_view.rs
+++ b/src/dioxus_ui/log_group_view.rs
@@ -8,34 +8,33 @@ use dioxus::prelude::*;
 pub struct LogGroupDetailProps {
     pub id: String,
     pub template: String, // Example: "User <*> logged in from <*>"
-    pub occurrences: usize,
+    pub occurrences: u32,
     // We might want to display a few sample raw log lines later
     // pub sample_lines: Vec<String>,
 }
 
 #[derive(Props, PartialEq, Clone)]
 pub struct LogGroupViewProps {
-    pub log_group: Option<LogGroupDetailProps>, // Option because a group might not be selected
+    pub selected_log_group: Option<LogGroupDetailProps>, // Option because a group might not be selected
 }
 
 pub fn LogGroupView(cx: Scope<LogGroupViewProps>) -> Element {
-    if let Some(details) = &cx.props.log_group {
-        cx.render(rsx! {
+    match &cx.props.selected_log_group {
+        Some(details) => cx.render(rsx! {
             div {
-                h2 { "Log Group Details (Dioxus)" }
-                p { "ID: {details.id}" }
-                p { "Template: {details.template}" }
-                p { "Occurrences: {details.occurrences}" }
-                // Placeholder for future elements like sample lines or navigation buttons
+                class: "p-4 border rounded shadow-md",
+                h2 { class: "text-xl font-semibold mb-2", "Log Group Details" }
+                div { class: "mb-1", strong { "ID: " } "{details.id}" }
+                div { class: "mb-1", strong { "Template: " } "{details.template}" }
+                div { strong { "Occurrences: " } "{details.occurrences}" }
             }
-        })
-    } else {
-        cx.render(rsx! {
+        }),
+        None => cx.render(rsx! {
             div {
-                h2 { "Log Group Details (Dioxus)" }
-                p { "No log group selected." }
+                class: "p-4 border rounded shadow-md text-gray-500",
+                "No log group selected"
             }
-        })
+        }),
     }
 }
 
@@ -44,10 +43,10 @@ fn _example_usage(cx: Scope) -> Element {
     let sample_detail = LogGroupDetailProps {
         id: "group_1".to_string(),
         template: "User <*> logged in from <*>".to_string(),
-        occurrences: 10,
+        occurrences: 10, // Note: This example occurrence will be u32
     };
     cx.render(rsx! {
-        LogGroupView { log_group: sample_detail }
-        LogGroupView {} // For the None case, rely on default
+        LogGroupView { selected_log_group: Some(sample_detail) }
+        LogGroupView { selected_log_group: None }
     })
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,10 @@
+// src/lib.rs
+
+// Declare the dioxus_ui module so it becomes part of the library.
+pub mod dioxus_ui;
+
+// If other top-level modules from src/ (like app, args, sources, ui)
+// are also intended to be part of the library, they should be declared here too.
+// For now, focusing on what dioxus_desktop.rs needs.
+// pub mod app; // Example: if LyreTail struct or other app logic is needed by other binaries/tests
+// pub mod args; // Example: if Args struct is needed


### PR DESCRIPTION
This commit introduces the initial implementation of Dioxus UI components and a new desktop binary target.

New Dioxus Components:
- `BaseTable`: Displays a summary of log groups.
- `LogGroupView`: Displays details of a selected log group.
- `App`: Root component for the Dioxus UI, now accepts log group data.

New Desktop Binary (`dioxus-desktop`):
- Creates a new binary target `src/bin/dioxus_desktop.rs`.
- Initializes and runs the Dioxus desktop application.
- Implements basic file reading:
    - Uses `rfd` to open a native file dialog.
    - Reads the selected file's content.
    - Performs a simple processing step (counts lines) to generate sample log group data.
- Launches the Dioxus `App` component, passing the processed data to be displayed in the `BaseTable`.

Updated `Cargo.toml`:
- Added the `[[bin]]` section for the new `dioxus-desktop` binary.
- Added `rfd` as a dependency.